### PR TITLE
Add default_volume and volume_remember options

### DIFF
--- a/spotraop/src/config_raop.c
+++ b/spotraop/src/config_raop.c
@@ -79,6 +79,8 @@ void SaveConfig(char *name, void *ref, bool full) {
 	XMLUpdateNode(doc, common, false, "alac_encode", "%d", (int) glMRConfig.AlacEncode);
 	XMLUpdateNode(doc, common, false, "encryption", "%d", (int) glMRConfig.Encryption);
 	XMLUpdateNode(doc, common, false, "read_ahead", "%d", (int) glMRConfig.ReadAhead);
+	XMLUpdateNode(doc, common, false, "default_volume", "%d", glMRConfig.DefaultVolume);
+	XMLUpdateNode(doc, common, false, "volume_remember", "%d", (int) glMRConfig.VolumeRemember);
 
 	for (int i = 0; i < MAX_RENDERERS; i++) {
 		IXML_Node *dev_node;
@@ -154,6 +156,8 @@ static void LoadConfigItem(tMRConfig *Conf, char *name, char *val) {
 	if (!strcmp(name, "volume_feedback")) Conf->VolumeFeedback = atol(val);
 	if (!strcmp(name, "volume_mode")) Conf->VolumeMode = atol(val);
 	if (!strcmp(name, "alac_encode")) Conf->AlacEncode = atol(val);
+	if (!strcmp(name, "default_volume")) Conf->DefaultVolume = atoi(val);
+	if (!strcmp(name, "volume_remember")) Conf->VolumeRemember = atoi(val);
 	if (!strcmp(name, "name")) strcpy(Conf->Name, val);
 }
 

--- a/spotraop/src/spotraop.c
+++ b/spotraop/src/spotraop.c
@@ -88,6 +88,8 @@ tMRConfig			glMRConfig = {
 							2,				 // VolumeMode = HARDWARE
 							VOLUME_FEEDBACK, // VolumeFeedback
 							true,			 // AlacEncode
+						-1,				 // DefaultVolume (-1 = use device current)
+						false,			 // VolumeRemember
 					};
 
 /*----------------------------------------------------------------------------*/
@@ -536,7 +538,8 @@ static bool AddRaopDevice(struct sMR *Device, mdnssd_service_t *s) {
 	Device->PlayerIP 		= s->addr;
 	Device->PlayerPort 		= s->port;
 	Device->PlayerStatus	= 0;
-	Device->Volume			= -30.0;
+	Device->Volume			= Device->Config.DefaultVolume >= 0 ?
+								-30.0 * (1.0 - Device->Config.DefaultVolume / 100.0) : -30.0;
 	Device->SkipStart 		= 0;
 	Device->SkipDir 		= false;
 	Device->SpotPlayer		= NULL;
@@ -811,7 +814,13 @@ static void *ActiveRemoteThread(void *args) {
 					Device->Muted = false;
 					spotNotify(Device->SpotPlayer, SHADOW_VOLUME, (int) ((30.0 + volume) / 30.0 * UINT16_MAX));
 					raopcl_set_volume(Device->Raop, volume > -30 ? volume : -144);
-				} 
+					if (Device->Config.VolumeRemember && volume > -30.0) {
+						int newDefault = (int)((volume + 30.0) / 30.0 * 100.0 + 0.5);
+						if (newDefault > 100) newDefault = 100;
+						Device->Config.DefaultVolume = newDefault;
+						SaveConfig(glConfigName, glConfigID, false);
+					}
+				}
 			}
 		}
 

--- a/spotraop/src/spotraop.h
+++ b/spotraop/src/spotraop.h
@@ -56,6 +56,8 @@ typedef struct sMRConfig
 	int			VolumeMode;
 	int			VolumeFeedback;
 	bool		AlacEncode;
+	int			DefaultVolume;
+	bool		VolumeRemember;
 } tMRConfig;
 
 

--- a/spotupnp/src/config_upnp.c
+++ b/spotupnp/src/config_upnp.c
@@ -73,6 +73,8 @@ void SaveConfig(char *name, void *ref, bool full) {
 	XMLUpdateNode(doc, common, false, "use_filecache", "%d", glMRConfig.CacheMode);
 	XMLUpdateNode(doc, common, false, "gapless", "%d", glMRConfig.Gapless);
 	XMLUpdateNode(doc, common, false, "artwork", "%s", glMRConfig.ArtWork);
+	XMLUpdateNode(doc, common, false, "default_volume", "%d", glMRConfig.DefaultVolume);
+	XMLUpdateNode(doc, common, false, "volume_remember", "%d", (int) glMRConfig.VolumeRemember);
 
 	// mutex is locked here so no risk of a player being destroyed in our back
 	for (int i = 0; i < glMaxDevices; i++) {
@@ -138,6 +140,8 @@ static void LoadConfigItem(tMRConfig *Conf, char *name, char *val) {
 	if (!strcmp(name, "use_filecache")) Conf->CacheMode = atoi(val);
 	if (!strcmp(name, "gapless")) Conf->Gapless = atoi(val);
 	if (!strcmp(name, "artwork")) strcpy(Conf->ArtWork, val);
+	if (!strcmp(name, "default_volume")) Conf->DefaultVolume = atoi(val);
+	if (!strcmp(name, "volume_remember")) Conf->VolumeRemember = atoi(val);
 	if (!strcmp(name, "credentials")) strcpy(Conf->Credentials, val);
 	if (!strcmp(name, "name")) strcpy(Conf->Name, val);
 	if (!strcmp(name, "mac"))  {

--- a/spotupnp/src/spotupnp.c
+++ b/spotupnp/src/spotupnp.c
@@ -78,6 +78,8 @@ tMRConfig			glMRConfig = {
 							true,				 // SendMetaData
 							false,				 // SendCoverArt
 							"",					 // artwork
+							-1,					 // DefaultVolume (-1 = use device current)
+							false,				 // VolumeRemember
 					};
 
 /*----------------------------------------------------------------------------*/
@@ -476,6 +478,10 @@ static void ProcessEvent(Upnp_EventType EventType, const void *_Event, void *Coo
 			LOG_INFO("[%p]: UPnP Volume local change %d:%d (%s)", Device, (int) Volume, (int) GroupVolume, Device->Master ? "slave": "master");
 			Volume = GroupVolume < 0 ? Volume / Device->Config.MaxVolume : GroupVolume / 100;
 			spotNotify(Device->SpotPlayer, SHADOW_VOLUME, (int) (Volume * UINT16_MAX));
+			if (Device->Config.VolumeRemember) {
+				Device->Config.DefaultVolume = (int) Device->Volume;
+				SaveConfig(glConfigName, glConfigID, false);
+			}
 		}
 	}
 
@@ -1096,6 +1102,13 @@ static bool AddMRDevice(struct sMR* Device, char* UDN, IXML_Document* DescDoc, c
 
 	Device->Master = GetMaster(Device, &friendlyName);
 	Device->Volume = CtrlGetVolume(Device);
+
+	if (Device->Config.DefaultVolume >= 0) {
+		Device->Volume = Device->Config.DefaultVolume;
+		Device->VolumeStampTx = gettime_ms();
+		CtrlSetVolume(Device, (uint8_t) Device->Volume, NULL);
+		LOG_INFO("[%p]: setting default volume %d", Device, Device->Config.DefaultVolume);
+	}
 
 	// set remaining items now that we are sure
 	if (*Device->Service[TOPOLOGY_IDX].ControlURL) {

--- a/spotupnp/src/spotupnp.h
+++ b/spotupnp/src/spotupnp.h
@@ -64,6 +64,8 @@ typedef struct sMRConfig
 	bool		SendMetaData;
 	bool		SendCoverArt;
 	char		ArtWork[4*STR_LEN];
+	int			DefaultVolume;
+	bool		VolumeRemember;
 } tMRConfig;
 
 struct sMR {


### PR DESCRIPTION
Adds two new config options to both spotupnp and spotraop:

- `default_volume` (0-100, -1 = disabled): volume to set when device first connects
- `volume_remember` (bool): when enabled, automatically updates default_volume when user changes volume on device

Closes #3

Generated with [Claude Code](https://claude.ai/code)