### PR TITLE
Add default_volume and volume_remember config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ The default configuration file is `config.xml`, stored in the same directory as 
 - `enabled <0|1>` : in common section, enables new discovered players by default. In a dedicated section, enables the player
 - `name`        : The name that will appear for the device in Spotify. You can change the default name.
 - `vorbis_rate <96|160|320>` : set the Spotify bitrate (default 160)
+- `default_volume <-1|0..100>` : set the volume level when a device first connects. `-1` (default) means do not override — for UPnP devices the current hardware volume is queried; for AirPlay devices the volume starts at minimum. Any value from `0` to `100` sets the device to that volume on connect.
+- `volume_remember <0|1>` : when enabled (`1`), automatically saves the current volume as `default_volume` whenever the user changes volume on the device via Spotify. This effectively restores the device to the last Spotify-controlled volume level on the next connection. Default is `0` (disabled).
 
 ##### UPnP
 - `upnp_max`    : set the maximum UPnP version use to search players (default 1)


### PR DESCRIPTION
Adds two new config options to both spotupnp and spotraop, and documents them in README.md:

- `default_volume` (0-100, -1 = disabled): volume to set when device first connects
- `volume_remember` (bool): when enabled, automatically updates default_volume when user changes volume on device

Closes #3

Generated with [Claude Code](https://claude.ai/code)