### PR TITLE
Increment version to v0.20.2 with NoriLabs Edition

### DIFF
--- a/spotraop/src/spotraop.h
+++ b/spotraop/src/spotraop.h
@@ -20,7 +20,7 @@
 #include "cross_util.h"
 #include "spotify.h"
 
-#define VERSION "v0.20.1" " (" __DATE__ " @ " __TIME__ ")"
+#define VERSION "v0.20.2 (NoriLabs Edition)" " (" __DATE__ " @ " __TIME__ ")"
 
 /*----------------------------------------------------------------------------*/
 /* typedefs */

--- a/spotupnp/src/spotupnp.h
+++ b/spotupnp/src/spotupnp.h
@@ -22,7 +22,7 @@
 #include "metadata.h"
 #include "spotify.h"
 
-#define VERSION "v0.20.1"" ("__DATE__" @ "__TIME__")"
+#define VERSION "v0.20.2 (NoriLabs Edition)"" ("__DATE__" @ "__TIME__")"
 
 /*----------------------------------------------------------------------------*/
 /* typedefs */


### PR DESCRIPTION
Increments version from v0.20.1 to v0.20.2 and adds "(NoriLabs Edition)" to the version string printed at startup in both spotupnp and spotraop components.

Closes #8

Generated with [Claude Code](https://claude.ai/code)