### PR TITLE
fix: validate ZeroConf required fields and fix SIGFPE handler ordering

### DIFF
--- a/spotraop/src/spotify.cpp
+++ b/spotraop/src/spotify.cpp
@@ -201,6 +201,16 @@ auto CSpotPlayer::postHandler(struct mg_connection* conn) {
     if (requestInfo->content_length > 0) {
         body.resize(requestInfo->content_length);
         mg_read(conn, body.data(), requestInfo->content_length);
+    } else if (requestInfo->content_length < 0) {
+        // chunked or unknown Content-Length — read until connection closes
+        char buf[4096];
+        int n;
+        while ((n = mg_read(conn, buf, sizeof(buf))) > 0) body.append(buf, n);
+    }
+
+    if (!body.empty()) {
+        CSPOT_LOG(info, "ZeroConf POST body (%zu bytes): %.256s", body.size(), body.c_str());
+
         mg_header hd[64];
         int num = mg_split_form_urlencoded(body.data(), hd, 64);
         std::map<std::string, std::string> queryMap;
@@ -210,11 +220,23 @@ auto CSpotPlayer::postHandler(struct mg_connection* conn) {
             queryMap[hd[i].name] = hd[i].value;
         }
 
-        // Pass user's credentials to the blob
-        blob->loadZeroconfQuery(queryMap);
+        CSPOT_LOG(info, "ZeroConf parsed %d fields: blob=%s clientKey=%s userName=%s",
+                  num,
+                  queryMap["blob"].empty() ? "MISSING" : "present",
+                  queryMap["clientKey"].empty() ? "MISSING" : "present",
+                  queryMap["userName"].empty() ? "MISSING" : queryMap["userName"].c_str());
 
-        // We have the blob, proceed to login
-        clientConnected.give();
+        // Guard: if blob or clientKey are missing, Shannon cipher will get keyLength=0
+        // causing SIGFPE via key[i % keyLength]. Do not proceed without required fields.
+        if (queryMap["blob"].empty() || queryMap["clientKey"].empty()) {
+            CSPOT_LOG(error, "ZeroConf POST missing required fields (blob or clientKey) — not connecting");
+        } else {
+            // Pass user's credentials to the blob
+            blob->loadZeroconfQuery(queryMap);
+
+            // We have the blob, proceed to login
+            clientConnected.give();
+        }
     }
 
 #ifdef BELL_ONLY_CJSON

--- a/spotraop/src/spotraop.c
+++ b/spotraop/src/spotraop.c
@@ -1052,11 +1052,13 @@ static bool Stop(void) {
 /*---------------------------------------------------------------------------*/
 #if !defined(_MSC_VER) && !defined(WIN)
 static void sigfpe_handler(int sig, siginfo_t *si, void *ctx) {
-	void *bt[64];
-	int n = backtrace(bt, 64);
+	// Write the banner FIRST before backtrace(), so we always see it even if
+	// backtrace() itself crashes (common on static binaries lacking unwind tables).
 	const char msg[] = "\n*** SIGFPE: integer division/modulo by zero in cspot or libraop ***\n"
 	                   "Stack trace (resolve with: addr2line -e spotraop-linux-x86_64-static -f <addr>):\n";
 	(void) write(STDERR_FILENO, msg, sizeof(msg) - 1);
+	void *bt[64];
+	int n = backtrace(bt, 64);
 	backtrace_symbols_fd(bt, n, STDERR_FILENO);
 	signal(SIGFPE, SIG_DFL);
 	raise(SIGFPE);


### PR DESCRIPTION
Guard against missing 'blob' or 'clientKey' in ZeroConf POST body. When these fields are absent (chunked encoding, truncated body), Shannon cipher receives keyLength=0 causing SIGFPE via key[i % 0]. Now logs the raw body and field presence for diagnosis, handles chunked/unknown Content-Length, and skips connection if required fields are missing rather than crashing.

Also fixes SIGFPE handler to write banner before backtrace().

Fixes #11

Generated with [Claude Code](https://claude.ai/code)) • [`claude/issue-11-20260327-0248`](https://github.com/jacob5948/SpotConnect/tree/claude/issue-11-20260327-0248